### PR TITLE
Bump HUnit upper bound

### DIFF
--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -151,7 +151,7 @@ Test-Suite test-evp-base64
     Main-Is: Test/OpenSSL/EVP/Base64.hs
     Build-Depends:
         HsOpenSSL,
-        HUnit                >= 1.0 && < 1.3,
+        HUnit                >= 1.0 && < 1.4,
         base                 == 4.*,
         bytestring           >= 0.9 && < 0.11,
         test-framework       >= 0.8 && < 0.9,


### PR DESCRIPTION
Verified locally on Ubuntu with GHC 7.10.2

stackage issue: https://github.com/fpco/stackage/issues/768
