### PR TITLE
DER reading/writing for X509, X509Req, & RSA

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ examples/Server
 
 .cabal-sandbox
 cabal.sandbox.config
+.stack-work/

--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -146,6 +146,19 @@ Test-Suite test-dsa
     GHC-Options:
         -Wall
 
+Test-Suite test-rsa
+    Type:    exitcode-stdio-1.0
+    Main-Is: Test/OpenSSL/RSA.hs
+    Build-Depends:
+        HsOpenSSL,
+        HUnit                >= 1.0 && < 1.3,
+        base                 == 4.*,
+        bytestring           >= 0.9 && < 0.11,
+        test-framework       >= 0.8 && < 0.9,
+        test-framework-hunit >= 0.3 && < 0.4
+    GHC-Options:
+        -Wall
+
 Test-Suite test-evp-base64
     Type:    exitcode-stdio-1.0
     Main-Is: Test/OpenSSL/EVP/Base64.hs

--- a/HsOpenSSL.cabal
+++ b/HsOpenSSL.cabal
@@ -54,7 +54,7 @@ Library
         bytestring >= 0.9   && < 0.11,
         network    >= 2.1   && < 2.7,
         old-locale >= 1.0   && < 1.1,
-        time       >= 1.1.1 && < 1.6
+        time       >= 1.1.1 && < 1.9
         -- old-locale is only needed if time < 1.5, but Cabal does not
         -- allow us to express conditional dependencies like this.
 

--- a/OpenSSL/RSA.hsc
+++ b/OpenSSL/RSA.hsc
@@ -24,19 +24,28 @@ module OpenSSL.RSA
     , rsaIQMP
     , rsaCopyPublic
     , rsaKeyPairFinalize -- private
+      -- * DER encoding
+    , fromDERPub
+    , toDERPub
     )
     where
 #include "HsOpenSSL.h"
 import Control.Monad
+import Data.ByteString (ByteString)
+import qualified Data.ByteString as B (useAsCStringLen)
+import qualified Data.ByteString.Internal as BI (createAndTrim)
 import Data.Typeable
+import Foreign.C.String (CString)
 #if MIN_VERSION_base(4,5,0)
-import Foreign.C.Types (CInt(..))
+import Foreign.C.Types (CInt(..), CLong(..))
 #else
-import Foreign.C.Types (CInt)
+import Foreign.C.Types (CInt, CLong)
 #endif
 import Foreign.ForeignPtr (ForeignPtr, finalizeForeignPtr, newForeignPtr, withForeignPtr)
+import Foreign.Marshal.Alloc (alloca)
 import Foreign.Ptr (FunPtr, Ptr, freeHaskellFunPtr, nullFunPtr, nullPtr)
 import Foreign.Storable (Storable(..))
+import GHC.Word (Word8)
 import OpenSSL.BN
 import OpenSSL.Utils
 import System.IO.Unsafe (unsafePerformIO)
@@ -233,6 +242,31 @@ rsaDMQ1 = peekMI (#peek RSA, dmq1)
 rsaIQMP :: RSAKeyPair -> Maybe Integer
 rsaIQMP = peekMI (#peek RSA, iqmp)
 
+{- DER encoding ------------------------------------------------------------- -}
+
+foreign import ccall unsafe "d2i_RSAPublicKey"
+        _fromDERPub :: Ptr (Ptr RSA) -> Ptr CString -> CLong -> IO (Ptr RSA)
+
+foreign import ccall unsafe "i2d_RSAPublicKey"
+        _toDERPub :: Ptr RSA -> Ptr (Ptr Word8) -> IO CInt
+
+-- |Parse a public key from ASN.1 DER format
+fromDERPub :: ByteString -> Maybe RSAPubKey
+fromDERPub bs = unsafePerformIO . usingConvedBS $ \(csPtr, ci) -> do
+    rsaPtr <- _fromDERPub nullPtr csPtr ci
+    if rsaPtr == nullPtr then return Nothing else
+        Just . RSAPubKey <$> newForeignPtr _free rsaPtr
+    where usingConvedBS io = B.useAsCStringLen bs $ \(cs, len) ->
+              alloca $ \csPtr -> poke csPtr cs >> io (csPtr, fromIntegral len)
+
+-- |Dump a public key to ASN.1 DER format
+toDERPub :: RSAPubKey -> ByteString
+toDERPub (RSAPubKey k) = unsafePerformIO $ do
+    requiredSize <- withForeignPtr k $ flip _toDERPub nullPtr
+    BI.createAndTrim (fromIntegral requiredSize) $ \ptr ->
+        alloca $ \pptr ->
+            (fromIntegral <$>) $ withForeignPtr k $ \key ->
+                poke pptr ptr >> _toDERPub key pptr
 
 {- instances ---------------------------------------------------------------- -}
 

--- a/OpenSSL/X509.hs
+++ b/OpenSSL/X509.hs
@@ -70,6 +70,7 @@ import OpenSSL.EVP.Internal
 import OpenSSL.Utils
 import OpenSSL.Stack
 import OpenSSL.X509.Name
+import Data.ByteString.Lazy (ByteString)
 
 -- |@'X509'@ is an opaque object that represents X.509 certificate.
 newtype X509  = X509 (ForeignPtr X509_)
@@ -200,11 +201,11 @@ writeX509' bio x509
            >>  return ()
 
 -- |@'writeDerX509' cert@ writes an X.509 certificate to DER string.
-writeDerX509 :: X509 -> IO String
+writeDerX509 :: X509 -> IO ByteString
 writeDerX509 x509
     = do mem <- newMem
          writeX509' mem x509
-         bioRead mem
+         bioReadLBS mem
 
 readX509' :: BIO -> IO X509
 readX509' bio
@@ -214,9 +215,9 @@ readX509' bio
            >>= wrapX509 
 
 -- |@'readDerX509' der@ reads in a certificate.
-readDerX509 :: String -> IO X509
+readDerX509 :: ByteString -> IO X509
 readDerX509 derStr
-    = newConstMem derStr >>= readX509'
+    = newConstMemLBS derStr >>= readX509'
 
 -- |@'compareX509' cert1 cert2@ compares two certificates.
 compareX509 :: X509 -> X509 -> IO Ordering

--- a/OpenSSL/X509/Request.hs
+++ b/OpenSSL/X509/Request.hs
@@ -29,6 +29,8 @@ module OpenSSL.X509.Request
 
     , getPublicKey
     , setPublicKey
+
+    , addExtensions
     )
     where
 
@@ -46,12 +48,14 @@ import           OpenSSL.X509 (X509)
 import qualified OpenSSL.X509 as Cert
 import           OpenSSL.X509.Name
 import           Data.ByteString.Lazy (ByteString)
+import           OpenSSL.Stack
 
 -- |@'X509Req'@ is an opaque object that represents PKCS#10
 -- certificate request.
 newtype X509Req  = X509Req (ForeignPtr X509_REQ)
 data    X509_REQ
 
+data    X509_EXT
 
 foreign import ccall unsafe "X509_REQ_new"
         _new :: IO (Ptr X509_REQ)
@@ -88,6 +92,13 @@ foreign import ccall unsafe "X509_REQ_get_pubkey"
 
 foreign import ccall unsafe "X509_REQ_set_pubkey"
         _set_pubkey :: Ptr X509_REQ -> Ptr EVP_PKEY -> IO CInt
+
+foreign import ccall unsafe "X509V3_EXT_nconf_nid"
+        _ext_create :: Ptr a -> Ptr b -> CInt -> CString -> IO (Ptr X509_EXT)
+
+foreign import ccall unsafe "X509_REQ_add_extensions"
+        _req_add_extensions :: Ptr X509_REQ -> Ptr STACK -> IO CInt
+
 
 -- |@'newX509Req'@ creates an empty certificate request. You must set
 -- the following properties to and sign it (see 'signX509Req') to
@@ -227,6 +238,21 @@ setPublicKey req pkey
       _set_pubkey reqPtr pkeyPtr
            >>= failIf (/= 1)
            >>  return ()
+
+
+-- |@'addExtensions' req [(nid, str)]@
+--
+-- E.g., nid 85 = 'subjectAltName' http://osxr.org:8080/openssl/source/crypto/objects/objects.h#0476
+--
+-- (TODO: more docs; NID type)
+addExtensions :: X509Req -> [(Int, String)] -> IO CInt
+addExtensions req exts =
+  withX509ReqPtr req $ \reqPtr -> do
+    extPtrs <- forM exts make
+    withStack extPtrs $ _req_add_extensions reqPtr
+
+  where
+    make (nid, str) = withCString str $ _ext_create nullPtr nullPtr (fromIntegral nid)
 
 
 -- |@'makeX509FromReq' req cert@ creates an empty X.509 certificate

--- a/Test/OpenSSL/RSA.hs
+++ b/Test/OpenSSL/RSA.hs
@@ -8,7 +8,7 @@ test_encodeDecodeEqual :: Test
 test_encodeDecodeEqual = TestCase $ do
   keyPair <- generateRSAKey 1024 3 Nothing
   pubKey <- rsaCopyPublic keyPair
-  assertEqual "encodeDecode" (Just pubKey) (fromDERPub (toDERPub pubKey))
+  assertEqual "encodeDecode" (Just pubKey) (fromDERPub (toDERPub keyPair))
 
 main :: IO ()
 main = TF.defaultMain $ TF.hUnitTestToTests test_encodeDecodeEqual

--- a/Test/OpenSSL/RSA.hs
+++ b/Test/OpenSSL/RSA.hs
@@ -1,0 +1,14 @@
+module Main (main) where
+import OpenSSL.RSA
+import qualified Test.Framework as TF
+import qualified Test.Framework.Providers.HUnit as TF
+import Test.HUnit
+
+test_encodeDecodeEqual :: Test
+test_encodeDecodeEqual = TestCase $ do
+  keyPair <- generateRSAKey 1024 3 Nothing
+  pubKey <- rsaCopyPublic keyPair
+  assertEqual "encodeDecode" (Just pubKey) (fromDERPub (toDERPub pubKey))
+
+main :: IO ()
+main = TF.defaultMain $ TF.hUnitTestToTests test_encodeDecodeEqual

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,34 +1,8 @@
-# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+resolver: lts-8.3
 
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-4.2
-
-# Local packages, usually specified by relative directory name
 packages:
 - '.'
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
-
-# Override default flag values for local packages and extra-deps
 flags:
   HsOpenSSL:
     fast-bignum: false
-
-# Extra package databases containing global packages
-extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: >= 1.0.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,34 @@
+# For more information, see: https://github.com/commercialhaskell/stack/blob/release/doc/yaml_configuration.md
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-4.2
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps: []
+
+# Override default flag values for local packages and extra-deps
+flags:
+  HsOpenSSL:
+    fast-bignum: false
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]


### PR DESCRIPTION
This PR incorporates code from myself, @newsham, and @shak-mar to provide DER (de)serialization for different OpenSSL types.

Also included is support for adding X509v3 extensions (e.g., subjectAltName) to `X509Req`s.

These branches are merged in this PR:
- PR https://github.com/phonohawk/HsOpenSSL/pull/39 from @newsham
- PR https://github.com/phonohawk/HsOpenSSL/pull/46 from @shak-mar

Also relevant:
- Bug https://github.com/phonohawk/HsOpenSSL/issues/21
